### PR TITLE
Enabled Back-Pushing of CI Output

### DIFF
--- a/samples/.drone.yml
+++ b/samples/.drone.yml
@@ -1,36 +1,59 @@
 kind: pipeline
-name: default
+name: gin-proc
 
 clone:
   disable: true
 
 steps:
-- name: clone
-  image: docker:git
+- name: prepare
+  image: falconshock/gin-proc
   environment:
-    REPO: test
-    GIN_USER: "wahal"
-    GIN_SERVER: "172.19.0.2"
     SSH_KEY:
       from_secret: DRONE_PRIVATE_SSH_KEY  
   commands:
-    - echo "[+] Starting SSH Agent."
+    #- echo "[+] Preparing Environment"
+    #- apt-get update && apt-get install git-annex python3.6 python3-pip -y
+
+    # "[+] Starting SSH Agent"
     - eval $(ssh-agent -s)
-    - echo "[+] Installing SSH Keys."
+    
+    # "[+] Installing SSH Keys"
     - mkdir /root/.ssh && echo "$SSH_KEY" > /root/.ssh/id_rsa && chmod 0600 /root/.ssh/id_rsa
     - echo "StrictHostKeyChecking no" >> /etc/ssh/ssh_config
-    - ssh-keyscan -H "$GIN_SERVER" >> /root/.ssh/known_hosts
+    #- ssh-keyscan -H "$DRONE_SYSTEM_HOST" >> /root/.ssh/known_hosts
     - ssh-add /root/.ssh/id_rsa
-#    - ssh -Tv git@172.19.0.2 -p 22 -i /root/.ssh/id_rsa
-    - echo "[+] Cloning Repository."
-    - git clone git@"$GIN_SERVER":/"$GIN_USER"/"$REPO".git
+    #- ssh -Tv git@"$DRONE_SYSTEM_HOST" -p 22 -i /root/.ssh/id_rsa
+    
+    # "[+] Cloning Repository."
+    - git clone "$DRONE_GIT_SSH_URL"
+    - cd "$DRONE_REPO_NAME"/
 
-- name: proc
-  image: ubuntu
-  environment:
-    REPO: test
-  commands:
-    - apt-get update
-    - apt-get install python -y
-    - which python
+    - pip3 install -r requirements.txt
 
+    - git annex init ""$DRONE_REPO_NAME"-drone-annexe"
+    - git annex sync --content
+    # "Annex syncing complete."
+
+    # --------------------------
+    # Your code.
+    # --------------------------
+
+    - mkdir "$DRONE_BUILD_NUMBER"
+    - git diff-tree -r --no-commit-id --name-only origin/master . | xargs -I '{}' cp '{}' "$DRONE_BUILD_NUMBER"/
+
+    # "[+] Back-Pushing output."
+    - git checkout gin-proc || git checkout -b gin-proc
+    - git add "$DRONE_BUILD_NUMBER"/ && git commit "$DRONE_BUILD_NUMBER"/ -m "$DRONE_COMMIT_MESSAGE" && git push origin gin-proc
+
+- name: slack
+  image: plugins/slack
+  settings:
+    webhook: https://hooks.slack.com/services/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
+
+trigger:
+  branch:
+  - master
+  event:
+  - push
+  status:
+  - success


### PR DESCRIPTION
[1] Removed unnecessary user inputs that were required earlier.
[2] Enabled back-pushing of CI output to `gin-proc` branch in gin repo.
[3] Yet to give option for user to choose whether to save the output or not.