### PR TITLE
Enable repository in Drone when writing configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,32 @@
 FROM python:3
 
+# Create directories
 RUN mkdir -p /app/backend
 RUN mkdir -p /app/frontend
+WORKDIR /app
 
-COPY back-end/. /app/backend
-COPY front-end/. /app/frontend
 COPY images /app/images
 
-COPY requirements.txt /app
-WORKDIR /app
-RUN pip install --no-cache-dir -r requirements.txt
-
+# Install NPM
 RUN apt-get update
 RUN apt-get install -y npm
 
+# Copy and install front-end
 WORKDIR /app/frontend
+COPY front-end/. /app/frontend
 RUN npm install npm@latest -g
 RUN npm install nuxt -g
 
 RUN npm install
 RUN nuxt build
+
+# Install Python dependencies
+WORKDIR /app
+COPY requirements.txt /app
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy back-end code and images
+COPY back-end/. /app/backend
 
 WORKDIR /app
 

--- a/back-end/config.py
+++ b/back-end/config.py
@@ -364,7 +364,7 @@ def ensureConfig(config_path, userInputs, workflow='snakemake', annexFiles=[],
     Runs following checks:
 
         1. Whether or not a pipeline configuration already exists.
-        2. If it exists, is it corrupt or un-processible?
+        2. If it exists, is it corrupt or un-processable?
         3. If not, do the preparation commands required in
         execution step match our standards.
 

--- a/back-end/config.py
+++ b/back-end/config.py
@@ -25,14 +25,14 @@ prep_commands = (
     'git config --global user.name "gin-proc"',
     'git config --global user.email "gin-proc@local"',
     'ssh-keyscan -t rsa "$DRONE_GOGS_SERVER" > /root/.ssh/authorized_keys',
-    '''if [ -d "$DRONE_REPO_NAME" ]; then
-           cd "$DRONE_REPO_NAME"/;
-           git fetch --all;
-           git checkout -f "$DRONE_COMMIT";
-       else
-           git clone "$DRONE_GIT_SSH_URL";
-           cd "$DRONE_REPO_NAME"/;
-       fi'''
+    ('if [ -d "$DRONE_REPO_NAME" ]; then'
+     '  cd "$DRONE_REPO_NAME"/;'
+     '  git fetch --all;'
+     '  git checkout -f "$DRONE_COMMIT";'
+     'else'
+     '  git clone "$DRONE_GIT_SSH_URL";'
+     '  cd "$DRONE_REPO_NAME"/;'
+     'fi')
 )
 
 

--- a/back-end/config.py
+++ b/back-end/config.py
@@ -330,7 +330,7 @@ def ensure_config(config_path, user_commands, workflow='snakemake',
                     data=config['steps']
                 )
 
-                yaml.dump(config, stream, default_flow_style=False)
+                yaml.dump(config, stream, default_flow_style=False, width=1000)
 
     except ConfigurationError as e:
         log('error', e)
@@ -343,7 +343,8 @@ def ensure_config(config_path, user_commands, workflow='snakemake',
                                                notifications=notifications)
             if not generated_config:
                 return False
-            yaml.dump(generated_config, new_config, default_flow_style=False)
+            yaml.dump(generated_config, new_config, default_flow_style=False,
+                      width=1000)
 
 
 def create_drone_file(config_path, user_commands, workflow='snakemake',
@@ -356,6 +357,7 @@ def create_drone_file(config_path, user_commands, workflow='snakemake',
                                            notifications=notifications)
         if not generated_config:
             return False
-        yaml.dump(generated_config, new_config, default_flow_style=False)
+        yaml.dump(generated_config, new_config, default_flow_style=False,
+                  width=1000)
 
     return True

--- a/back-end/config.py
+++ b/back-end/config.py
@@ -175,7 +175,7 @@ def generate_config(workflow, commands, input_files, output_files,
                     environment={
                         'SSH_KEY': {'from_secret': 'DRONE_PRIVATE_SSH_KEY'}
                     },
-                    commands=prep_commands
+                    commands=list(prep_commands)
                 ),
                 create_step(
                     name='rebuild-cache',

--- a/back-end/config.py
+++ b/back-end/config.py
@@ -132,7 +132,6 @@ def create_workflow(workflow, commands, user_commands=None):
 
 def generate_config(workflow, commands, input_files, output_files,
                     notifications):
-
     """
     Automates generation of a fresh configuration for Drone
     by adding necessary vanilla state pipeline steps and
@@ -286,7 +285,6 @@ def ensure_config(config_path, user_commands, workflow='snakemake',
     can also be accessed at:
 
     https://github.com/G-Node/gin-proc/blob/master/docs/operations.md
-
     """
     if not input_files:
         input_files = list()
@@ -334,10 +332,7 @@ def ensure_config(config_path, user_commands, workflow='snakemake',
                     data=config['steps']
                 )
 
-                yaml.dump(
-                    config,
-                    stream,
-                    default_flow_style=False)
+                yaml.dump(config, stream, default_flow_style=False)
 
     except ConfigurationError as e:
         log('error', e)
@@ -351,3 +346,18 @@ def ensure_config(config_path, user_commands, workflow='snakemake',
             if not generated_config:
                 return False
             yaml.dump(generated_config, new_config, default_flow_style=False)
+
+
+def create_drone_file(config_path, user_commands, workflow='snakemake',
+                      input_files=None, output_files=None, notifications=None):
+    with open(os.path.join(config_path, '.drone.yml'), 'w') as new_config:
+        generated_config = generate_config(workflow=workflow,
+                                           commands=user_commands,
+                                           input_files=input_files,
+                                           output_files=output_files,
+                                           notifications=notifications)
+        if not generated_config:
+            return False
+        yaml.dump(generated_config, new_config, default_flow_style=False)
+
+    return True

--- a/back-end/config.py
+++ b/back-end/config.py
@@ -78,19 +78,18 @@ def add_output_files(files, commands):
     """
 
     if len(files) > 0:
-        inputdronefiles = join_drone_files(files)
+        input_drone_files = join_drone_files(files)
 
         commands.append('TMPLOC=`mktemp -d`')
-        commands.append(('mv {} "$TMPLOC"').format(inputdronefiles))
+        commands.append(f'mv {input_drone_files} "$TMPLOC"')
 
         commands.append('git checkout gin-proc || git checkout -b gin-proc')
         commands.append('git reset --hard')
         commands.append('mkdir "$DRONE_BUILD_NUMBER"')
 
-        inputdronefiles = join_drone_files(files, "$TMPLOC")
+        input_drone_files = join_drone_files(files, "$TMPLOC")
 
-        commands.append('mv {} "$DRONE_BUILD_NUMBER"/'.format(
-            inputdronefiles))
+        commands.append(f'mv {input_drone_files} "$DRONE_BUILD_NUMBER"/')
 
         commands.append('git annex add -c annex.largefiles="largerthan=10M" '
                         '"$DRONE_BUILD_NUMBER"/')
@@ -106,9 +105,9 @@ def add_input_files(files, commands):
     Adds commands to 'git annex get' input files to ensure annexed content
     """
     if len(files) > 0:
-        inputdronefiles = join_drone_files(files)
+        input_drone_files = join_drone_files(files)
         commands.append("git annex init gin-proc")
-        commands.append("git annex get {}".format(inputdronefiles))
+        commands.append(f"git annex get {input_drone_files}")
 
     return commands
 

--- a/back-end/config.py
+++ b/back-end/config.py
@@ -26,13 +26,13 @@ prep_commands = (
     'git config --global user.email "gin-proc@local"',
     'ssh-keyscan -t rsa "$DRONE_GOGS_SERVER" > /root/.ssh/authorized_keys',
     ('if [ -d "$DRONE_REPO_NAME" ]; then'
-     '  cd "$DRONE_REPO_NAME"/;'
-     '  git fetch --all;'
-     '  git checkout -f "$DRONE_COMMIT";'
-     'else'
-     '  git clone "$DRONE_GIT_SSH_URL";'
-     '  cd "$DRONE_REPO_NAME"/;'
-     'fi')
+     ' cd "$DRONE_REPO_NAME"/;'
+     ' git fetch --all;'
+     ' git checkout -f "$DRONE_COMMIT";'
+     ' else'
+     ' git clone "$DRONE_GIT_SSH_URL";'
+     ' cd "$DRONE_REPO_NAME"/;'
+     ' fi')
 )
 
 
@@ -315,15 +315,14 @@ def ensure_config(config_path, user_commands, workflow='snakemake',
                     )
 
             with open(dronefile, 'w') as stream:
-
-                config['steps'][config['steps'].index(
-                    execution_step)]['commands'] = modify_config_files(
+                exec_step_idx = config['steps'].index(execution_step)
+                exec_step = config['steps'][exec_step_idx]
+                exec_step['commands'] = modify_config_files(
                     workflow=workflow,
                     input_files=input_files,
                     output_files=output_files,
                     commands=user_commands,
-                    data=config['steps'][config['steps'].index(execution_step)]
-                    ['commands'][:len(prep_commands)]
+                    data=exec_step['commands'][:len(prep_commands)]
                 )
 
                 config['steps'] = add_notifications(

--- a/back-end/config.py
+++ b/back-end/config.py
@@ -355,14 +355,8 @@ def addNotifications(notifications, data):
     return data
 
 
-def ensureConfig(
-        config_path,
-        userInputs,
-        workflow='snakemake',
-        annexFiles=[],
-        backPushFiles=[],
-        notifications=[]
-        ):
+def ensureConfig(config_path, userInputs, workflow='snakemake', annexFiles=[],
+                 backPushFiles=[], notifications=[]):
 
     """
     First line of defense!

--- a/back-end/server.py
+++ b/back-end/server.py
@@ -93,19 +93,15 @@ user = User()
 
 @auth.route('/logout', methods=['POST'])
 def logout():
-
     """
     Clears user's credentials including auth token for the session.
     """
-
-    if request.method == "POST":
-        return user.logout()
+    return user.logout()
 
 
 @auth.route('/login', methods=['POST'])
 @cross_origin()
 def login():
-
     """
     Authenticates user with their GIN credentials.
 
@@ -136,12 +132,10 @@ def login():
         build jobs inside its runners.
     @@@
     """
-
-    if request.method == "POST":
-        try:
-            return user.login()
-        except errors.ServerError as e:
-            abort(e.status)
+    try:
+        return user.login()
+    except errors.ServerError as e:
+        abort(e.status)
 
 
 @auth.route('/user', methods=['GET'])
@@ -165,13 +159,10 @@ def execute_workflow():
     For complete documentation of execution steps, read
     https://github.com/G-Node/gin-proc/blob/master/docs/operations.md
     """
-
-    if request.method == "POST":
-
-        try:
-            return user.run(request)
-        except errors.ServerError as e:
-            abort(e.status)
+    try:
+        return user.run(request)
+    except errors.ServerError as e:
+        abort(e.status)
 
 
 @api.route('/repos', methods=['GET'])
@@ -180,8 +171,7 @@ def repositories():
     """
     Returns list of user's repositories from GIN.
     """
-    if request.method == "GET":
-        return user.repos()
+    return user.repos()
 
 
 app.register_blueprint(api, url_prefix='/api')

--- a/back-end/server.py
+++ b/back-end/server.py
@@ -58,7 +58,7 @@ class User(object):
         return "logged out", HTTPStatus.OK
 
     def details(self):
-        return gin_get_user_data(self.gin_token), HTTPStatus.OK
+        return gin_get_user_data(self.gin_token)
 
     def run(self, request):
         try:
@@ -149,11 +149,11 @@ def get_user():
     """
     Returns logged-in user's data from GIN.
     """
-    if request.method == "GET":
-        try:
-            return user.details()
-        except errors.ServerError as e:
-            abort(e.status)
+    res = user.details()
+    if res.ok:
+        return res.json()
+
+    return res.text, res.status_code
 
 
 @api.route('/execute', methods=['POST'])

--- a/back-end/server.py
+++ b/back-end/server.py
@@ -34,31 +34,31 @@ class User(object):
 
     def __init__(self, *args, **kwargs):
         self.username = None
-        self.GIN_TOKEN = None
+        self.gin_token = None
 
     def login(self):
         self.username = request.json['username']
         password = request.json['password']
 
         try:
-            self.GIN_TOKEN = gin_ensure_token(user.username, password)
+            self.gin_token = gin_ensure_token(user.username, password)
             log("debug", 'GIN token ensured.')
         except errors.ServerError as e:
             log('critical', e)
             return e, HTTPStatus.INTERNAL_SERVER_ERROR
 
-        if ensure_key(self.GIN_TOKEN) and drone_ensure_secrets(self.username):
-            return {'token': self.GIN_TOKEN}, HTTPStatus.OK
+        if ensure_key(self.gin_token) and drone_ensure_secrets(self.username):
+            return {'token': self.gin_token}, HTTPStatus.OK
         else:
             return 'login failed', HTTPStatus.UNAUTHORIZED
 
     def logout(self):
         user.username = None
-        user.GIN_TOKEN = None
+        user.gin_token = None
         return "logged out", HTTPStatus.OK
 
     def details(self):
-        return gin_get_user_data(self.GIN_TOKEN), HTTPStatus.OK
+        return gin_get_user_data(self.gin_token), HTTPStatus.OK
 
     def run(self, request):
         try:
@@ -73,7 +73,7 @@ class User(object):
                     request.json['annexFiles'].values()))),
                 output_files=list(filter(None, list(
                     request.json['backpushFiles'].values()))),
-                token=self.GIN_TOKEN,
+                token=self.gin_token,
                 username=self.username
             )
             msg = "Success: workflow pushed to {}".format(request.json['repo'])
@@ -84,7 +84,7 @@ class User(object):
     def repos(self):
         return jsonify([
             {'value': repo['name'], 'text': self.username + '/' + repo['name']}
-            for repo in gin_get_repos(self.username, self.GIN_TOKEN)
+            for repo in gin_get_repos(self.username, self.gin_token)
         ])
 
 

--- a/back-end/service.py
+++ b/back-end/service.py
@@ -17,7 +17,7 @@ from shutil import rmtree
 import tempfile
 
 from http import HTTPStatus
-from config import ensure_config
+from config import create_drone_file
 from logger import log
 from subprocess import call
 from errors import ServiceError, ServerError
@@ -379,8 +379,9 @@ def configure(repo_name, user_commands, output_files, input_files,
 
     with tempfile.TemporaryDirectory() as temp_clone_path:
         clone_path = clone(repo, username, temp_clone_path)
-        ensure_config(config_path=clone_path, workflow=workflow,
-                      user_commands=user_commands, input_files=input_files,
-                      output_files=output_files, notifications=notifications)
+        create_drone_file(config_path=clone_path, workflow=workflow,
+                          user_commands=user_commands, input_files=input_files,
+                          output_files=output_files,
+                          notifications=notifications)
         push(clone_path, commit_message)
         clean(clone_path)

--- a/back-end/service.py
+++ b/back-end/service.py
@@ -77,7 +77,10 @@ def drone_enable_repo(repo):
     automatically creates a hook on GIN for triggering builds on push.
     """
     repopath = repo["full_name"]
-    res = requests.post(DRONE_ADDR + f"/api/repos/{repopath}")
+    headers = {'Authorization': 'Bearer {}'.format(os.environ['DRONE_TOKEN']),
+               'Content-Type': "application/json"}
+    res = requests.post(DRONE_ADDR + f"/api/repos/{repopath}",
+                        headers=headers)
     if res.status_code != HTTPStatus.OK:
         raise ServerError(f"Failed to enable hook for {repopath}",
                           HTTPStatus.INTERNAL_SERVER_ERROR)

--- a/back-end/service.py
+++ b/back-end/service.py
@@ -153,7 +153,7 @@ def drone_ensure_secrets(user):
     for repo in repos:
         if not repo["active"]:
             continue
-        repopath = repo["slug"]
+        repopath = repo["slug"]  # Drone equivalent for repository full_name
         secrets = requests.get(
             DRONE_ADDR + f"/api/repos/{repopath}/secrets",
             headers={'Authorization': 'Bearer {}'.format(

--- a/back-end/service.py
+++ b/back-end/service.py
@@ -346,7 +346,7 @@ def configure(repoName, userInputs, backPushFiles, annexFiles, commitMessage,
     """
     First line of action!
 
-    This function is reposible for integrating the entire workflow
+    This function is responsible for integrating the entire workflow
     together and executing the following in chronological order:
 
         1. Fetches the repository data for repo in question.

--- a/back-end/service.py
+++ b/back-end/service.py
@@ -177,7 +177,7 @@ def gin_get_keys(token):
 def gin_ensure_key(token):
     """
     Confirms whether the public key 'gin-proc' is installed
-    on usre's GIN account or not.
+    on user's GIN account or not.
     """
     for key in gin_get_keys(token):
         if key['title'] == PRIV_KEY:
@@ -307,7 +307,7 @@ def gin_get_repo_data(user, repo, token):
     ).json()
 
 
-def clone(repo, author, path):
+def gin_clone(repo, author, path):
     """
     Clones the repository in question in a temporary location (path).
     """
@@ -374,7 +374,7 @@ def configure(repo_name, user_commands, output_files, input_files,
     os.environ['GIT_SSH_COMMAND'] = f"ssh -i {keypath}"
 
     with tempfile.TemporaryDirectory() as temp_clone_path:
-        clone_path = clone(repo, username, temp_clone_path)
+        clone_path = gin_clone(repo, username, temp_clone_path)
         create_drone_file(config_path=clone_path, workflow=workflow,
                           user_commands=user_commands, input_files=input_files,
                           output_files=output_files,

--- a/back-end/service.py
+++ b/back-end/service.py
@@ -29,7 +29,7 @@ from cryptography.hazmat.backends import default_backend
 GIN_ADDR = os.environ['GIN_SERVER']
 DRONE_ADDR = os.environ['DRONE_SERVER']
 
-PRIV_KEY = 'gin_id_rsa'
+PRIV_KEY = 'gin-proc'
 PUB_KEY = '{}.pub'.format(PRIV_KEY)
 SSH_PATH = os.path.join(os.environ['HOME'], 'gin-proc', 'ssh')
 

--- a/back-end/service.py
+++ b/back-end/service.py
@@ -39,7 +39,7 @@ def gin_get_user_data(token):
     Returns logged-in user's data from GIN.
     """
     return requests.get(GIN_ADDR + "/api/v1/user",
-                        headers={'Authorization': f'token {token}'}).json()
+                        headers={'Authorization': f'token {token}'})
 
 
 def gin_ensure_token(username, password):

--- a/back-end/service.py
+++ b/back-end/service.py
@@ -38,10 +38,8 @@ def gin_get_user_data(token):
     """
     Returns logged-in user's data from GIN.
     """
-    return requests.get(
-        GIN_ADDR + "/api/v1/user",
-        headers={'Authorization': 'token {}'.format(token)}
-    ).json()
+    return requests.get(GIN_ADDR + "/api/v1/user",
+                        headers={'Authorization': f'token {token}'}).json()
 
 
 def gin_ensure_token(username, password):

--- a/front-end/pages/index.vue
+++ b/front-end/pages/index.vue
@@ -185,7 +185,7 @@
             'value': false,
             'icon': 'slack hash'
           }],
-          commitMessage: 'gin-proc is awesome',
+          commitMessage: 'Create/update drone.yml',
         },
         success_message: {
           visible: false,
@@ -241,7 +241,7 @@
             'value': false,
             'icon': 'slack hash'
           }],
-          commitMessage: 'gin-proc is awesome',
+          commitMessage: 'Create/update drone.yml',
           workflow: 'custom',
           },
           this.userInputs = {},

--- a/front-end/pages/login.vue
+++ b/front-end/pages/login.vue
@@ -8,11 +8,11 @@
       <sui-grid-column :width="8" verticalAlign="middle">
         <sui-form equalWidth @submit="login" @submit.stop.prevent>
             <sui-form-field>
-              <sui-input v-model="loginData.username" type="text" placeholder="Elon Musk" icon="user" />
+              <sui-input v-model="loginData.username" type="text" placeholder="GIN Username" icon="user" />
             </sui-form-field>
             <sui-form-field>
               <sui-input v-model="loginData.password" type="password"
-                placeholder="I'm_the_greatest_inventor_of_all_time" icon="key" />
+                placeholder="GIN password" icon="key" />
             </sui-form-field>
           <sui-form-field>
             <sui-label style="font-family: Menlo, Consolas, DejaVu Sans Mono, monospace;">Use your GIN credentials only.


### PR DESCRIPTION
Creating a drone configuration in the service now enables the repository in Drone, which in turn creates the hook on GIN for triggering builds when the repository receives a push.

Other changes:
- Major (and minor) codestyle fixes.
- Simplified drone.yml creation.  Reading and updating is currently unnecessary.
- Bug fixes for repository paths for API calls (partially addresses #55).